### PR TITLE
Change all most functions and structs to concrete types

### DIFF
--- a/src/camera.zig
+++ b/src/camera.zig
@@ -5,39 +5,37 @@ const Ray = ray.Ray;
 const Vec3 = vec3.Vec3;
 const scale = vec3.scale;
 
-pub fn Camera(comptime T: type) type {
-    return struct {
-        origin: Point3(T),
-        lower_left_corner: Point3(T),
-        horizontal: Vec3(T),
-        vertical: Vec3(T),
+pub const Camera = struct {
+    origin: Point3,
+    lower_left_corner: Point3,
+    horizontal: Vec3,
+    vertical: Vec3,
 
-        pub fn init() @This() {
-            const aspect_ratio = 16.0 / 9.0;
-            const viewport_height = 2.0;
-            const viewport_width = aspect_ratio * viewport_height;
-            const focal_length = 1.0;
-            const horizontal = Vec3(T){ viewport_width, 0, 0 };
-            const vertical = Vec3(T){ 0, viewport_height, 0 };
-            const half_hor = scale(T, 0.5, horizontal);
-            const half_vert = scale(T, 0.5, vertical);
-            const origin = Point3(T){ 0, 0, 0 };
+    pub fn init() @This() {
+        const aspect_ratio = 16.0 / 9.0;
+        const viewport_height = 2.0;
+        const viewport_width = aspect_ratio * viewport_height;
+        const focal_length = 1.0;
+        const horizontal = Vec3{ viewport_width, 0, 0 };
+        const vertical = Vec3{ 0, viewport_height, 0 };
+        const half_hor = scale(0.5, horizontal);
+        const half_vert = scale(0.5, vertical);
+        const origin = Point3{ 0, 0, 0 };
 
-            return .{
-                .origin = origin,
-                .horizontal = horizontal,
-                .vertical = vertical,
-                .lower_left_corner = origin - half_hor - half_vert - Vec3(T){ 0, 0, focal_length },
-            };
-        }
+        return .{
+            .origin = origin,
+            .horizontal = horizontal,
+            .vertical = vertical,
+            .lower_left_corner = origin - half_hor - half_vert - Vec3{ 0, 0, focal_length },
+        };
+    }
 
-        pub fn get_ray(self: *const @This(), u: T, v: T) Ray(T) {
-            const uhor = scale(T, u, self.horizontal);
-            const vvert = scale(T, v, self.vertical);
-            return .{
-                .orig = self.origin,
-                .dir = self.lower_left_corner + uhor + vvert - self.origin,
-            };
-        }
-    };
-}
+    pub fn get_ray(self: *const @This(), u: f32, v: f32) Ray {
+        const uhor = scale(u, self.horizontal);
+        const vvert = scale(v, self.vertical);
+        return .{
+            .orig = self.origin,
+            .dir = self.lower_left_corner + uhor + vvert - self.origin,
+        };
+    }
+};

--- a/src/color.zig
+++ b/src/color.zig
@@ -7,23 +7,23 @@ const clamp = @import("rtweekend.zig").clamp;
 
 // clamp(comptime T: type, x: T, lo: T, hi: T) T {
 
-fn pgm_scale(comptime T: type, c: T) i32 {
-    return @floatToInt(i32, 256 * clamp(T, c, 0.0, 0.999));
+fn pgm_scale(c: f32) i32 {
+    return @floatToInt(i32, 256 * clamp(f32, c, 0.0, 0.999));
 }
 
-pub fn write_color(comptime WriterType: type, out: WriterType, comptime T: type, pixel_color: Color(T), samples_per_pixel: i32) !void {
+pub fn write_color(comptime WriterType: type, out: WriterType, pixel_color: Color, samples_per_pixel: i32) !void {
     var rf = pixel_color[0];
     var gf = pixel_color[1];
     var bf = pixel_color[2];
 
-    const s = 1.0 / @intToFloat(T, samples_per_pixel);
+    const s = 1.0 / @intToFloat(f32, samples_per_pixel);
     rf = @sqrt(s * rf);
     gf = @sqrt(s * gf);
     bf = @sqrt(s * bf);
 
-    const r = pgm_scale(T, rf);
-    const g = pgm_scale(T, gf);
-    const b = pgm_scale(T, bf);
+    const r = pgm_scale(rf);
+    const g = pgm_scale(gf);
+    const b = pgm_scale(bf);
 
     try out.print("{} {} {}\n", .{ r, g, b });
 }

--- a/src/hittable_list.zig
+++ b/src/hittable_list.zig
@@ -11,32 +11,30 @@ const HitParameters = hittable.HitParameters;
 const HitRecord = hittable.HitRecord;
 
 // TODO: the rest of the owl
-pub fn HittableList(comptime T: type) type {
-    return struct {
-        // the original code uses shared pointers,
-        // but the objects are all const, so we don't
-        // need atomic refcounting. Also we are confident in our ability
-        // to manage memory manually in such a simple application.
-        objects: std.ArrayList(*(Hittable(T))),
+pub const HittableList = struct {
+    // the original code uses shared pointers,
+    // but the objects are all const, so we don't
+    // need atomic refcounting. Also we are confident in our ability
+    // to manage memory manually in such a simple application.
+    objects: std.ArrayList(*(Hittable)),
 
-        pub fn hit(self: *@This(), r: Ray(T), t_min: T, t_max: T, rec: *HitRecord(T)) bool {
-            var temp_rec: HitRecord(T) = rec.*; // copy values instead of undefined
-            var hit_anything = false;
-            var closest_so_far = t_max;
+    pub fn hit(self: *@This(), r: Ray, t_min: f32, t_max: f32, rec: *HitRecord) bool {
+        var temp_rec: HitRecord = rec.*; // copy values instead of undefined
+        var hit_anything = false;
+        var closest_so_far = t_max;
 
-            for (self.objects.items) |*object| {
-                if (object.*.hit(r, t_min, closest_so_far, &temp_rec)) {
-                    hit_anything = true;
-                    closest_so_far = temp_rec.t;
-                    // error: cannot assign to constant
-                    rec.* = temp_rec;
-                }
+        for (self.objects.items) |*object| {
+            if (object.*.hit(r, t_min, closest_so_far, &temp_rec)) {
+                hit_anything = true;
+                closest_so_far = temp_rec.t;
+                // error: cannot assign to constant
+                rec.* = temp_rec;
             }
-            return hit_anything;
         }
+        return hit_anything;
+    }
 
-        pub fn add(self: *@This(), obj: *(Hittable(T))) !void {
-            try self.objects.append(obj);
-        }
-    };
-}
+    pub fn add(self: *@This(), obj: *(Hittable)) !void {
+        try self.objects.append(obj);
+    }
+};

--- a/src/main.zig
+++ b/src/main.zig
@@ -18,13 +18,9 @@ const Camera = camera.Camera;
 const write_color = color.write_color;
 const Sphere = sphere.Sphere;
 const Ray = ray.Ray;
-const Vec3 = vec3.Vec3;
+const Vec3 = vec3.Vec3(f32);
 const Point3 = vec3.Point3;
-const Vec3_init = vec3.Vec3_init;
 const Color = vec3.Color;
-const Color_init = vec3.Color_init;
-const Point3_init = vec3.Point3_init;
-const Ray_init = ray.Ray_init;
 const dot = vec3.dot;
 const length_squared = vec3.length_squared;
 const HitRecord = hittable.HitRecord;
@@ -39,22 +35,22 @@ const buffer_size: usize = 4096;
 const random_float = vec3.RandFloatFn(f32).random;
 const random_in_hemisphere = vec3.RandVecFn(f32).random_in_hemisphere;
 
-fn ray_color(comptime T: type, r: *Ray(T), world: *Hittable(T), depth: i32, rand: anytype) Color(T) {
+fn ray_color(r: *Ray, world: *Hittable, depth: i32, rand: anytype) Color {
     if (depth <= 0) {
-        return Color(T){ 0, 0, 0 };
+        return Color{ 0, 0, 0 };
     }
-    var rec: HitRecord(T) = undefined;
-    if (world.hit(r.*, 0.001, inf(T), &rec)) {
-        const target: Point3(T) = rec.p + random_in_hemisphere(rec.normal, rand);
-        var ri = Ray_init(T, rec.p, target - rec.p);
-        const rc = ray_color(T, &ri, world, depth - 1, rand);
-        return scale(T, @as(T, 0.5), rc);
+    var rec: HitRecord = undefined;
+    if (world.hit(r.*, 0.001, inf(f32), &rec)) {
+        const target: Point3 = rec.p + random_in_hemisphere(rec.normal, rand);
+        var ri = Ray{ .orig = rec.p, .dir = target - rec.p };
+        const rc = ray_color(&ri, world, depth - 1, rand);
+        return scale(@as(f32, 0.5), rc);
     }
 
-    const unit_direction = unit_vector(T, r.dir);
+    const unit_direction = unit_vector(r.dir);
     const t = 0.5 * (unit_direction[1] + 1.0);
-    const gray = scale(T, 1.0 - t, Color(T){ 1.0, 1.0, 1.0 });
-    const blue = scale(T, t, Color(T){ 0.5, 0.7, 1.0 });
+    const gray = scale(1.0 - t, Color{ 1.0, 1.0, 1.0 });
+    const blue = scale(t, Color{ 0.5, 0.7, 1.0 });
     const final_color = gray + blue;
     return final_color;
 }
@@ -72,7 +68,7 @@ pub fn main() anyerror!void {
     const samples_per_pixel: i32 = 100;
 
     // Camera
-    const cam = Camera(f32).init();
+    const cam = Camera.init();
 
     // Initialize the world along with its geometric entities
     // start with a general purpose allocator
@@ -81,45 +77,45 @@ pub fn main() anyerror!void {
     const allocator = gpa.allocator();
 
     // initialize array list for storing `Hittable(T)` objects
-    var objects = ArrayList(*(Hittable(f32))).init(allocator);
+    var objects = ArrayList(*Hittable).init(allocator);
     defer objects.deinit();
 
     // construct world object using the hittables
-    var world_hlist: HittableList(f32) = .{ .objects = objects };
+    var world_hlist: HittableList = .{ .objects = objects };
     defer world_hlist.objects.deinit();
 
     // the world has two spheres, a small one and a large one
     // Initialize the small sphere first
-    // const small_sphere_allocd = try allocator.alloc(Sphere(f32), 1);
+    // const small_sphere_allocd = try allocator.alloc(Sphere, 1);
     // defer allocator.free(small_sphere_allocd);
 
     // Initialize and add the sphere to the array_list of objects in the world
-    // const small_sphere_ptr = @ptrCast(*(Sphere(f32)), small_sphere_allocd);
+    // const small_sphere_ptr = @ptrCast(*(Sphere), small_sphere_allocd);
     // TODO: create an init function
-    // small_sphere_ptr.center = Point3(f32){ 0, 0, -1 };
+    // small_sphere_ptr.center = Point3{ 0, 0, -1 };
     // small_sphere_ptr.radius = @as(f32, 0.5);
-    var small_sphere: Sphere(f32) = .{
-        .center = Point3(f32){ 0, 0, -1 },
+    var small_sphere: Sphere = .{
+        .center = Point3{ 0, 0, -1 },
         .radius = @as(f32, 0.5),
     };
-    var small_sphere_hittable = Hittable(f32).make(&small_sphere);
+    var small_sphere_hittable = Hittable.make(&small_sphere);
     try world_hlist.add(&small_sphere_hittable);
 
     // same for the larger sphere
-    // const large_sphere_allocd = try allocator.alloc(Sphere(f32), 1);
+    // const large_sphere_allocd = try allocator.alloc(Sphere, 1);
     // defer allocator.free(large_sphere_allocd);
-    // const large_sphere_ptr = @ptrCast(*(Sphere(f32)), large_sphere_allocd);
-    // large_sphere_ptr.center = Point3(f32){ 0, -100.5, -1 };
+    // const large_sphere_ptr = @ptrCast(*(Sphere), large_sphere_allocd);
+    // large_sphere_ptr.center = Point3{ 0, -100.5, -1 };
     // large_sphere_ptr.radius = @as(f32, 100);
-    var large_sphere: Sphere(f32) = .{
-        .center = Point3(f32){ 0, -100.5, -1 },
+    var large_sphere: Sphere = .{
+        .center = Point3{ 0, -100.5, -1 },
         .radius = @as(f32, 100),
     };
-    var large_sphere_hittable = Hittable(f32).make(&large_sphere);
+    var large_sphere_hittable = Hittable.make(&large_sphere);
     try world_hlist.add(&large_sphere_hittable);
 
-    // make a Hittable(f32) out of the HittableList(f32) object that is the world
-    var world = Hittable(f32).make(&world_hlist);
+    // make a Hittable out of the HittableList object that is the world
+    var world = Hittable.make(&world_hlist);
 
     try bufout.print("P3\n{} {}\n255\n", .{ image_width, image_height });
 
@@ -138,15 +134,15 @@ pub fn main() anyerror!void {
         std.debug.print("{} out of {} lines remaining\n", .{ j + 1, image_height });
         var i: i32 = 0;
         while (i < image_width) : (i += 1) {
-            var pixel_color = Color(f32){ 0, 0, 0 };
+            var pixel_color = Color{ 0, 0, 0 };
             var s: i32 = 0;
             while (s < samples_per_pixel) : (s += 1) {
                 const u = (@intToFloat(f32, i) + random_float(rand)) / dw;
                 const v = (@intToFloat(f32, j) + random_float(rand)) / dh;
                 var r = cam.get_ray(u, v);
-                pixel_color += ray_color(f32, &r, &world, max_depth, rand);
+                pixel_color += ray_color(&r, &world, max_depth, rand);
             }
-            try write_color(@TypeOf(bufout), bufout, f32, pixel_color, samples_per_pixel);
+            try write_color(@TypeOf(bufout), bufout, pixel_color, samples_per_pixel);
         }
     }
 

--- a/src/ray.zig
+++ b/src/ray.zig
@@ -3,20 +3,11 @@ const Vec3 = vec3.Vec3;
 const Point3 = vec3.Point3;
 const scale = vec3.scale;
 
-pub fn Ray(comptime T: type) type {
-    return struct {
-        orig: Point3(T),
-        dir: Vec3(T),
+pub const Ray = struct {
+    orig: Point3,
+    dir: Vec3,
 
-        pub fn at(self: *const @This(), t: T) Vec3(T) {
-            return self.orig + scale(T, t, self.dir);
-        }
-    };
-}
-
-pub fn Ray_init(comptime T: type, orig: Point3(T), dir: Vec3(T)) Ray(T) {
-    return Ray(T){
-        .orig = orig,
-        .dir = dir,
-    };
-}
+    pub fn at(self: *const @This(), t: f32) Vec3 {
+        return self.orig + scale(t, self.dir);
+    }
+};

--- a/src/sphere.zig
+++ b/src/sphere.zig
@@ -12,32 +12,30 @@ const length_squared = vec3.length_squared;
 const HitRecord = hittable.HitRecord;
 const Hittable = hittable.Hittable;
 
-pub fn Sphere(comptime T: type) type {
-    return struct {
-        center: Point3(T),
-        radius: T,
+pub const Sphere = struct {
+    center: Point3,
+    radius: f32,
 
-        pub fn hit(self: *@This(), r: Ray(T), t_min: T, t_max: T, rec: *(HitRecord(T))) bool {
-            const oc = r.orig - self.center;
-            const a = length_squared(T, r.dir);
-            const half_b = dot(T, oc, r.dir);
-            const c = length_squared(T, oc) - self.radius * self.radius;
+    pub fn hit(self: *@This(), r: Ray, t_min: f32, t_max: f32, rec: *HitRecord) bool {
+        const oc = r.orig - self.center;
+        const a = length_squared(r.dir);
+        const half_b = dot(oc, r.dir);
+        const c = length_squared(oc) - self.radius * self.radius;
 
-            const discriminant = half_b * half_b - a * c;
-            if (discriminant < 0) {
-                return false;
-            }
-            const sqrtd = @sqrt(discriminant);
-            var root = (-half_b - sqrtd) / a;
-            if ((root < t_min) or (t_max < root)) {
-                return false;
-            }
-            rec.t = root;
-            rec.p = r.at(rec.t);
-            const outward_normal: Vec3(T) = scale(T, 1 / self.radius, rec.p - self.center);
-            rec.set_face_normal(r, outward_normal);
-
-            return true;
+        const discriminant = half_b * half_b - a * c;
+        if (discriminant < 0) {
+            return false;
         }
-    };
-}
+        const sqrtd = @sqrt(discriminant);
+        var root = (-half_b - sqrtd) / a;
+        if ((root < t_min) or (t_max < root)) {
+            return false;
+        }
+        rec.t = root;
+        rec.p = r.at(rec.t);
+        const outward_normal: Vec3 = scale(1 / self.radius, rec.p - self.center);
+        rec.set_face_normal(r, outward_normal);
+
+        return true;
+    }
+};

--- a/src/vec3.zig
+++ b/src/vec3.zig
@@ -4,40 +4,33 @@ const expect = std.testing.expect;
 
 const Vector = std.meta.Vector;
 
-pub fn Vec3(comptime T: type) type {
-    return Vector(3, T);
+pub const Vec3 = Vector(3, f32);
+
+pub fn scale(t: f32, v: Vec3) Vec3 {
+    return [_]f32{ t * v[0], t * v[1], t * v[2] };
 }
 
-// TODO: deprecate
-pub fn Vec3_init(comptime T: type, x: T, y: T, z: T) Vector(3, T) {
-    return Vector(3, T){ x, y, z };
-}
-
-pub fn scale(comptime T: type, t: T, v: Vec3(T)) Vec3(T) {
-    return [_]T{ t * v[0], t * v[1], t * v[2] };
-}
-
-pub fn dot(comptime T: type, v1: Vec3(T), v2: Vec3(T)) T {
+pub fn dot(v1: Vec3, v2: Vec3) f32 {
     return @reduce(.Add, v1 * v2);
 }
 
-pub fn cross(comptime T: type, v1: Vec3(T), v2: Vec3(T)) Vec3(T) {
+pub fn cross(v1: Vec3, v2: Vec3) Vec3 {
     // 12 - 21, 20 - 02, 01 - 10
-    return [_]T{ v1[1] * v2[2] - v1[2] * v2[1], v1[2] * v2[0] - v1[0] * v2[2], v1[0] * v2[1] - v1[1] * v2[0] };
+    return [_]f32{ v1[1] * v2[2] - v1[2] * v2[1], v1[2] * v2[0] - v1[0] * v2[2], v1[0] * v2[1] - v1[1] * v2[0] };
 }
 
-pub fn magnitude(comptime T: type, v: Vec3(T)) T {
-    return @sqrt(dot(T, v, v));
+pub fn magnitude(v: Vec3) f32 {
+    return @sqrt(dot(v, v));
 }
 
-pub fn unit_vector(comptime T: type, v: Vec3(T)) Vec3(T) {
-    const m: T = magnitude(T, v);
-    const rv: Vec3(T) = scale(T, 1.0 / m, v);
+pub fn unit_vector(v: Vec3) Vec3 {
+    const m: f32 = magnitude(v);
+    const rv: Vec3 = scale(1.0 / m, v);
     return rv;
 }
 
-pub fn length_squared(comptime T: type, v: Vec3(T)) T {
-    return dot(T, v, v);
+pub fn length_squared(v: Vec3) f32 {
+    return dot(v, v);
 }
 
 pub fn RandFloatFn(comptime T: type) type {
@@ -57,8 +50,8 @@ pub fn RandFloatFn(comptime T: type) type {
 pub fn RandVecFn(comptime T: type) type {
     return struct {
         const Self = @This();
-        fn random(rand: anytype) Vec3(T) {
-            return Vec3(T){ rand.float(T), rand.float(T), rand.float(T) };
+        fn random(rand: anytype) Vec3 {
+            return Vec3{ rand.float(T), rand.float(T), rand.float(T) };
         }
 
         pub fn random_scaled(min: T, max: T, rand: anytype) T {
@@ -66,28 +59,28 @@ pub fn RandVecFn(comptime T: type) type {
             // into a vector?
             const s = (max - min);
             const nrv = Self.random(rand);
-            const base = Vec3(T){ min, min, min };
-            const sv = Vec3(T){ s, s, s };
+            const base = Vec3{ min, min, min };
+            const sv = Vec3{ s, s, s };
             return base + sv * nrv;
         }
 
-        pub fn random_in_unit_sphere(rand: anytype) Vec3(T) {
+        pub fn random_in_unit_sphere(rand: anytype) Vec3 {
             const x = RandFloatFn(T).random(rand);
             const ylim_sq = 1 - x * x;
             const ylim = @sqrt(ylim_sq);
             const y = RandFloatFn(T).random_scaled(-ylim, ylim, rand);
             const zlim = @sqrt(ylim_sq - y * y);
             const z = RandFloatFn(T).random_scaled(-zlim, zlim, rand);
-            return Vec3(T){ x, y, z };
+            return Vec3{ x, y, z };
         }
 
-        pub fn random_unit_vector(rand: anytype) Vec3(T) {
-            return unit_vector(T, random_in_unit_sphere(rand));
+        pub fn random_unit_vector(rand: anytype) Vec3 {
+            return unit_vector(random_in_unit_sphere(rand));
         }
 
-        pub fn random_in_hemisphere(normal: Vec3(T), rand: anytype) Vec3(T) {
+        pub fn random_in_hemisphere(normal: Vec3, rand: anytype) Vec3 {
             const in_unit_sphere = Self.random_in_unit_sphere(rand);
-            if (dot(T, in_unit_sphere, normal) > 0.0) {
+            if (dot(in_unit_sphere, normal) > 0.0) {
                 return in_unit_sphere;
             } else {
                 return -in_unit_sphere;


### PR DESCRIPTION
Making the structs and functions generic over the different floating point types lead to infinite comptime recursion when creating the material type: the material requires a pointer to hit record, and hit record requires a pointer to material. Not sure how else to work around this when intrusive/invasive types like this are involved.